### PR TITLE
Support passing claims directly to backdoor

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,39 +17,57 @@ end
 
 Add the following to your Phoenix router before other Guardian plugs.
 
-  ```elixir
-  if Mix.env() == :test do
-    plug Guardian.Plug.Backdoor, module: MyApp.Guardian
-  end
-  plug Guardian.Plug.VerifySession
-  ```
+```elixir
+if Mix.env() == :test do
+  plug Guardian.Plug.Backdoor, module: MyApp.Guardian
+end
+plug Guardian.Plug.VerifySession
+```
 
-  > NOTE: This plug is designed for acceptance testing and should never be added
-  to a production environment.
+> NOTE: This plug is designed for acceptance testing and should never be added
+> to a production environment.
 
-  ## Usage
+## Usage
 
-  Now that `Guardian.Plug.Backdoor` is installed, it's time to sign in. A simple GET request will work.
+Now that `Guardian.Plug.Backdoor` is installed, it's time to sign in. Pass your
+claims as `claims` in the query string of your route.
 
-  ```elixir
-  {:ok, token, _claims} = MyApp.Guardian.encode_and_sign(resource)
+```elixir
+conn = get(conn, "/", claims: %{sub: "User:1"})
 
-  conn = get(conn, "/?token=#{token}")
+resource = MyApp.Guardian.Plug.current_resource(conn)
+%{"sub" => "User:1"} = MyApp.Guardian.Plug.current_claims(conn)
+```
 
-  resource = MyApp.Guardian.Plug.current_resource(conn)
-  ```
+When the `Guardian.Plug.Backdoor` plug runs, it fetches the resource from your
+Guardian implementation with those claims and signs in.
 
-  When the `Guardian.Plug.Backdoor` plug runs, it looks up the resource from the `token` passed in and signs in.
+Alternatively, encode your claims into a token and pass that as `token` in the
+query string instead.
 
-  ### Hound
+```elixir
+{:ok, token, _claims} = MyApp.Guardian.encode_and_sign(resource)
 
-  If you're using [Hound](https://github.com/HashNuke/hound), you can write the following code.
+conn = get(conn, "/", token: token)
 
-  ```elixir
-  {:ok, token, _claims} = MyApp.Guardian.encode_and_sign(resource)
+resource = MyApp.Guardian.Plug.current_resource(conn)
+```
 
-  navigate_to("/?token=#{token}")
-  ```
+### Hound
+
+If you're using [Hound](https://github.com/HashNuke/hound), you can write the following code.
+
+```elixir
+query_params = Plug.Conn.Query.encode(claims: %{sub: "User:1"})
+
+navigate_to("/?" <> query_params)
+```
+
+```elixir
+{:ok, token, _claims} = MyApp.Guardian.encode_and_sign(resource)
+
+navigate_to("/?token=#{token}")
+```
 
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can

--- a/test/backdoor_test.exs
+++ b/test/backdoor_test.exs
@@ -5,8 +5,6 @@ defmodule Guardian.Plug.BackdoorTest do
 
   alias Guardian.Plug.Backdoor
 
-  @resource %{id: "bobby"}
-
   defmodule Impl do
     @moduledoc false
     use Guardian,
@@ -14,10 +12,17 @@ defmodule Guardian.Plug.BackdoorTest do
       secret_key: "guardian_backdoor"
 
     def subject_for_token(%{id: id}, _claims), do: {:ok, id}
-    def subject_for_token(%{"id" => id}, _claims), do: {:ok, id}
 
-    def resource_from_claims(%{"sub" => id}), do: {:ok, %{id: id}}
+    def resource_from_claims(%{"sub" => "bobby"}) do
+      {:ok, %{id: "bobby"}}
+    end
+
+    def resource_from_claims(_claims) do
+      {:error, :not_found}
+    end
   end
+
+  @resource %{id: "bobby"}
 
   setup do
     [
@@ -26,27 +31,45 @@ defmodule Guardian.Plug.BackdoorTest do
     ]
   end
 
-  test "fetch resource from token", context do
-    {:ok, token, _} = context.impl.encode_and_sign(@resource)
-
+  test "fetch resource from claims", context do
     conn =
-      conn(:get, "/?token=#{token}")
+      conn(:get, "/", claims: %{sub: @resource.id, foo: "bar"})
       |> Backdoor.call(Backdoor.init(module: context.impl))
 
     assert context.plug.current_resource(conn) == @resource
+    assert %{"sub" => "bobby", "foo" => "bar"} = context.plug.current_claims(conn)
   end
 
-  test "no resource without token", context do
+  test "no resource from invalid claims", context do
     conn =
-      conn(:get, "/")
+      conn(:get, "/", claims: %{sub: "invalid"})
       |> Backdoor.call(Backdoor.init(module: context.impl))
 
     assert context.plug.current_resource(conn) == nil
   end
 
+  test "fetch resource from token", context do
+    {:ok, token, _} = context.impl.encode_and_sign(@resource)
+
+    conn =
+      conn(:get, "/", token: token)
+      |> Backdoor.call(Backdoor.init(module: context.impl))
+
+    assert context.plug.current_resource(conn) == @resource
+    assert %{"sub" => "bobby"} = context.plug.current_claims(conn)
+  end
+
   test "no resource from invalid token", context do
     conn =
-      conn(:get, "/?token=foo")
+      conn(:get, "/", token: "invalid")
+      |> Backdoor.call(Backdoor.init(module: context.impl))
+
+    assert context.plug.current_resource(conn) == nil
+  end
+
+  test "no resource without token or claims", context do
+    conn =
+      conn(:get, "/")
       |> Backdoor.call(Backdoor.init(module: context.impl))
 
     assert context.plug.current_resource(conn) == nil


### PR DESCRIPTION
Rather than generate a token, pass claims directly through query strings. Passing

```
/?claims[sub]=User:1&claims[foo]=bar
```
is equivalent to signing in with

```elixir
%{"sub" => "User:1", "foo" => "bar"} = claims
```

This allows claims to be tailored exactly to testing needs, and avoids side effects from having to generate a token from `MyApp.Guardian.encode_and_sign(resource)`.